### PR TITLE
Use filenames for metric names

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const path = require('path')
 
 process.stdout.write(`; DO NOT EDIT - This is automatically generated\n`)
 process.stdout.write(
@@ -6,7 +7,8 @@ process.stdout.write(
 )
 
 for (const filename of fs.readdirSync('metrics')) {
-  const { fn, name } = require(`./metrics/${filename}`)
+  const fn = require(`./metrics/${filename}`)
+  const name = path.parse(filename).name
   process.stdout.write(`[${name}]\n`)
   process.stdout.write(`return (${fn.toString()})()`)
   process.stdout.write(`\n\n`)
@@ -63,23 +65,23 @@ return hasHeaderNavigation()
  * Iterates over all stylesheets in the document looking for rules with the
  * selector '.govuk-body-xs'. This will only find the rule that is *not* inside
  * a media query.
- * 
+ *
  * Returns 'true' if ALL instances of '.govuk-body-xs' have a font-size of
  * 0.0875rem which matches the new type scale.
- * 
+ *
  * Returns 'mixed' if AT LEAST ONE instance of '.govuk-body-xs' has a font-size
  * of 0.0875rem.
- * 
+ *
  * Returns 'false' if NO instances of '.govuk-body-xs' have a font-size of
  * 0.0875rem.
- * 
+ *
  * Returns 'unknown' if no instances of '.govuk-body-xs' are found.
  *
  * @returns string 'true'|'false'|'unknown'
  */
 function isUsingNewTypeScale() {
     const stylesheets = Array.from(document.styleSheets)
-        
+
     const $rules = stylesheets.map(stylesheet => {
         try {
             return Array.from(stylesheet.cssRules)
@@ -92,9 +94,9 @@ function isUsingNewTypeScale() {
     if ($rules.length === 0) {
         return 'unknown'
     }
-        
+
     const fontSizes = $rules.map(rule => rule.style["font-size"])
-    
+
     if (fontSizes.every(rule => rule == '0.875rem')) {
         return 'true'
     } else if (fontSizes.find(rule => rule == '0.875rem')) {

--- a/metrics/framework.js
+++ b/metrics/framework.js
@@ -1,6 +1,4 @@
-const name = 'framework'
-
-const fn = function () {
+module.exports = function () {
   if (
     window
       .getComputedStyle(document.documentElement)
@@ -19,5 +17,3 @@ const fn = function () {
 
   return 'Unknown'
 }
-
-module.exports = { name, fn }

--- a/metrics/frontend-version.js
+++ b/metrics/frontend-version.js
@@ -1,9 +1,5 @@
-const name = 'frontend-version'
-
-const fn = function () {
+module.exports = function () {
   return window
     .getComputedStyle(document.documentElement)
     .getPropertyValue('--govuk-frontend-version')
 }
-
-module.exports = { name, fn }

--- a/metrics/logo.js
+++ b/metrics/logo.js
@@ -1,6 +1,4 @@
-const name = 'logo'
-
-const fn = function () {
+module.exports = function () {
   const $svg = document.querySelector('.govuk-header__logotype')
 
   if (!$svg) {
@@ -22,5 +20,3 @@ const fn = function () {
       return 'unknown'
   }
 }
-
-module.exports = { name, fn }

--- a/metrics/root-has-rebrand-class.js
+++ b/metrics/root-has-rebrand-class.js
@@ -1,9 +1,5 @@
-const name = 'root-has-rebrand-class'
-
-const fn = function () {
+module.exports = function () {
   return document.documentElement.classList.contains(
     'govuk-template--rebranded'
   )
 }
-
-module.exports = { name, fn }

--- a/tests/framework.test.js
+++ b/tests/framework.test.js
@@ -4,17 +4,13 @@
 
 'use strict'
 
-const { fn, name } = require('../metrics/framework')
+const fn = require('../metrics/framework')
 
 describe('framework', () => {
   afterEach(() => {
     document.documentElement.innerHTML = ''
     document.documentElement.classList.remove('govuk-template')
     document.documentElement.style = ''
-  })
-
-  it('has a name of `framework`', () => {
-    expect(name).toBe('framework')
   })
 
   it('returns GOV.UK Frontend if the CSS custom property exists', () => {

--- a/tests/frontend-version.test.js
+++ b/tests/frontend-version.test.js
@@ -4,17 +4,13 @@
 
 'use strict'
 
-const { fn, name } = require('../metrics/frontend-version')
+const fn = require('../metrics/frontend-version')
 
 afterEach(() => {
   document.documentElement.style = ''
 })
 
 describe('frontend-version', () => {
-  it('has a name of frontend-version', () => {
-    expect(name).toBe('frontend-version')
-  })
-
   it('extracts the version of GOV.UK Frontend from the CSS custom property', () => {
     document.documentElement.style.setProperty(
       '--govuk-frontend-version',

--- a/tests/logo.test.js
+++ b/tests/logo.test.js
@@ -6,7 +6,7 @@
 
 const fs = require('fs')
 
-const { fn, name } = require('../metrics/logo')
+const fn = require('../metrics/logo')
 
 const fixturesPath = 'tests/fixtures/logo'
 const fixtures = fs
@@ -16,10 +16,6 @@ const fixtures = fs
 describe('logo', () => {
   afterEach(() => {
     document.documentElement.innerHTML = ''
-  })
-
-  it('has a name of logo', () => {
-    expect(name).toBe('logo')
   })
 
   it.each(fixtures)('%s should be detected as %s', (filename, expected) => {

--- a/tests/root-has-rebrand-class.test.js
+++ b/tests/root-has-rebrand-class.test.js
@@ -4,17 +4,13 @@
 
 'use strict'
 
-const { fn, name } = require('../metrics/root-has-rebrand-class')
+const fn = require('../metrics/root-has-rebrand-class')
 
 afterEach(() => {
   document.documentElement.classList.remove('govuk-template--rebranded')
 })
 
 describe('frontend-version', () => {
-  it('has a name of root-has-rebrand-class', () => {
-    expect(name).toBe('root-has-rebrand-class')
-  })
-
   it('returns true if the body has the `--rebranded` modifier class', () => {
     document.documentElement.classList.add('govuk-template--rebranded')
 


### PR DESCRIPTION
Rather than duplicating the name of the metric in both the filename and defining and exporting it from the metric JS file, just use the filename when generating the ini file.