### PR TITLE
Improve framework detection

### DIFF
--- a/metrics/framework.js
+++ b/metrics/framework.js
@@ -1,19 +1,24 @@
 module.exports = function () {
-  if (
+  const usesFrontend = [
     window
       .getComputedStyle(document.documentElement)
-      .getPropertyValue('--govuk-frontend-version')
-  ) {
-    return 'GOV.UK Frontend'
-  }
+      .getPropertyValue('--govuk-frontend-version'),
+    document.body.classList.contains('govuk-template__body')
+  ].some((result) => !!result)
 
-  if (document.documentElement.classList.contains('govuk-template')) {
-    return 'GOV.UK Frontend'
-  }
+  const usesLegacy = [
+    document.getElementById('skiplink-container'),
+    document.querySelector('.header-wrapper .header-global .header-logo')
+  ].some((result) => !!result)
 
-  if (document.getElementById('skiplink-container')) {
-    return 'GOV.UK Template / Frontend Toolkit / Elements'
+  switch (true) {
+    case usesFrontend && usesLegacy:
+      return 'GOV.UK Frontend + GOV.UK Template / Frontend Toolkit / Elements'
+    case usesFrontend:
+      return 'GOV.UK Frontend'
+    case usesLegacy:
+      return 'GOV.UK Template / Frontend Toolkit / Elements'
+    default:
+      return 'Unknown'
   }
-
-  return 'Unknown'
 }

--- a/tests/framework.test.js
+++ b/tests/framework.test.js
@@ -9,7 +9,7 @@ const fn = require('../metrics/framework')
 describe('framework', () => {
   afterEach(() => {
     document.documentElement.innerHTML = ''
-    document.documentElement.classList.remove('govuk-template')
+    document.body.classList.remove('govuk-template__body')
     document.documentElement.style = ''
   })
 
@@ -23,7 +23,7 @@ describe('framework', () => {
   })
 
   it('returns GOV.UK Frontend if the <body> has a govuk-template class', () => {
-    document.documentElement.classList.add('govuk-template')
+    document.body.classList.add('govuk-template__body')
 
     expect(fn()).toBe('GOV.UK Frontend')
   })
@@ -37,7 +37,43 @@ describe('framework', () => {
     expect(fn()).toBe('GOV.UK Template / Frontend Toolkit / Elements')
   })
 
+  it('returns GOV.UK Elements if Template header exists', () => {
+    document.body.innerHTML = `
+      <header role="banner" id="global-header" class="" data-landmark-index="0">
+      <div class="header-wrapper">
+        <div class="header-global">
+          <div class="header-logo">
+            <a href="" title="" id="logo" class="content" data-module="track-click" data-track-category="homeLinkClicked" data-track-action="homeHeader">
+              <img src="/govuk_template/assets/images/gov.uk_logotype_crown_invert_trans.png?0.26.0" width="36" height="32" alt=""> GOV.UK
+            </a>
+          </div>
+
+        </div>
+
+      </div>
+    </header>
+    `
+
+    expect(fn()).toBe('GOV.UK Template / Frontend Toolkit / Elements')
+  })
+
   it('returns unknown if no indicators are present', () => {
     expect(fn()).toBe('Unknown')
+  })
+
+  it('returns both if both frameworks are detected', () => {
+    document.documentElement.style.setProperty(
+      '--govuk-frontend-version',
+      '5.10.2'
+    )
+
+    const skipLink = document.createElement('div')
+    skipLink.setAttribute('id', 'skiplink-container')
+
+    document.documentElement.appendChild(skipLink)
+
+    expect(fn()).toBe(
+      'GOV.UK Frontend + GOV.UK Template / Frontend Toolkit / Elements'
+    )
   })
 })


### PR DESCRIPTION
For GOV.UK Frontend, additionally check for the `govuk-template__body` class on the `<body>` element.

For the legacy frameworks, additionally check for the header from GOV.UK Template.

Allow for the possibility that both GOV.UK Frontend and the legacy frameworks are in use at the same time.

Use `Array.prototype.some` to lazy evaluate the various checks.