### PR TITLE
Add GOV.UK prefix to product names

### DIFF
--- a/metrics/service-name.js
+++ b/metrics/service-name.js
@@ -10,10 +10,14 @@ module.exports = function () {
     title: 'head title'
   }
 
-  for (const selector of Object.values(selectors)) {
+  for (const [key, selector] of Object.entries(selectors)) {
     const element = document.querySelector(selector)
+    let prefix = ''
     if (element) {
-      return element.textContent.trim()
+      if (key === 'headerProductName') {
+        prefix = 'GOV.UK '
+      }
+      return prefix + element.textContent.trim()
     }
   }
 

--- a/tests/service-name.test.js
+++ b/tests/service-name.test.js
@@ -13,7 +13,7 @@ const fixtures = fs.readdirSync(fixturesPath).map((filename) => {
     return [filename, null]
   }
   if (filename === 'header-product-name.html') {
-    return [filename, 'Product name']
+    return [filename, 'GOV.UK Product name']
   }
   return [filename, 'Service name']
 })


### PR DESCRIPTION
All product names should begin with "GOV.UK", but we were previously only returning the non-logomark portion of the name (eg: "Pay" for "GOV.UK Pay").